### PR TITLE
Add evidence preservation step for compromises

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@
 >
 > Keep up to update from trusted newsfeed[^20][^21][^22][^23]. My personal choice is <https://socket.dev/blog>. Confirm with vulnerability databases like <https://security.snyk.io> or <https://socket.dev/search?e=npm>
 >
+> **Preserve evidence before cleanup**
+>
+> Before deleting caches or `node_modules`, preserve CI logs, package manager logs, lockfiles, `package.json`, npm token audit history, and a timestamped list of installed packages. This helps later root-cause analysis, credential-impact review, and any coordinated disclosure or insurance reporting.
+>
 > **Remove and replace compromised packages**
 >
 > ```sh


### PR DESCRIPTION
## Summary
- add an evidence-preservation step to the immediate compromise checklist
- call out CI logs, package manager logs, lockfiles, package manifests, token audit history, and installed package snapshots

## Rationale
During a suspected npm supply-chain compromise, teams often need to clean quickly, but preserving a minimal evidence set first supports root-cause analysis, credential-impact review, coordinated disclosure, and reporting requirements.

## Validation
- documentation-only change
- checked the README diff and wording